### PR TITLE
Correct number of measure bounding boxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The following datasets are referenced from this repository:
 | [Silva Online Handwritten Symbols](#silva-online-handwritten-symbols)                   	| Handwritten           	| 12600 symbols  	    									|                       								|                                           						|
 | [IMSLP](#imslp)                                                                         	| Printed               	| >420000 score images  									| PDF                      								| Various                                      						|
 | [Byrd Dataset](#byrd-dataset)                                                           	| Printed               	| 34 score images	    									| Images                   								| Various                                      						|
-| [Bounding Box Annotations of Musical Measures](#bounding-box-annotations-of-musical-measures)                                                           	| Printed               	| 940 score images; 53,017 bounding boxes	    									| Images                   								| Box Annotation Detection                                      						|
+| [Bounding Box Annotations of Musical Measures](#bounding-box-annotations-of-musical-measures)                                                           	| Printed               	| 940 score images; 24,329 bounding boxes	    									| Images                   								| Box Annotation Detection                                      						|
 
 
 If you find mistakes or know of any relevant datasets, that are missing in this list, please [open an issue](https://github.com/apacha/OMR-Datasets/issues/new) or directly file a pull request.


### PR DESCRIPTION
Due to a bug in our CSV export pipeline, there had been duplicates of bounding boxes in our data set. We now updated and corrected the CSV files. With this PR, I want to update the number of bounding boxes here... :no_mouth: